### PR TITLE
fix(lsp): skip indexing feature files without Feature declaration

### DIFF
--- a/godogen-language-server/features/workspace.feature
+++ b/godogen-language-server/features/workspace.feature
@@ -1,0 +1,54 @@
+Feature: Workspace File Handling
+  As a developer
+  I want the language server to handle edge cases in workspace files
+  So I can work with various file states gracefully
+
+  Rule: Empty feature files are not indexed
+
+    Scenario: Empty feature file is not indexed
+      Given empty.feature is added to the workspace:
+        """
+        """
+      Then steps.go has the following diagnostics:
+        """go
+        package steps
+
+        //godogen:given ^I have (\d+) cukes$
+        func IHaveCukes(count int) {}
+        """
+
+    Scenario: Feature file with only comments is not indexed
+      Given comments.feature is added to the workspace:
+        """
+        # This is just a comment
+        # No Feature declaration
+        """
+      Then steps.go has the following diagnostics:
+        """go
+        package steps
+
+        //godogen:given ^I have (\d+) cukes$
+        func IHaveCukes(count int) {}
+        """
+
+    Scenario: Empty feature file alongside valid feature file
+      Given empty.feature is added to the workspace:
+        """
+        """
+      And test.feature is added to the workspace:
+        """
+        Feature: Test
+          Scenario: Simple test
+            Given I have 5 cukes
+        """
+      Then steps.go has the following diagnostics:
+        """go
+        package steps
+
+        //godogen:given ^I have (\d+) cukes$
+        func IHaveCukes(count int) {}
+
+        //godogen:given ^I have (\d+) melons$
+        ^ HINT: Step definition is not used
+        func IHaveMelons(count int) {}
+        """

--- a/godogen-language-server/index/index.go
+++ b/godogen-language-server/index/index.go
@@ -295,6 +295,12 @@ func (index *Index) IndexWorkspaceFeatureFile(path string, content []byte) error
 		return err
 	}
 
+	// Skip files without a Feature declaration (e.g., empty files or comment-only files)
+	if document.Feature == nil {
+		slog.Debug("skipping file without Feature declaration", "component", "index", "path", path)
+		return nil
+	}
+
 	index.mx.Lock()
 	defer index.mx.Unlock()
 
@@ -329,6 +335,12 @@ func (index *Index) IndexDiskFeatureFile(path string, content []byte) error {
 	if err != nil {
 		slog.Debug("parse error", "component", "index", "path", path, "error", err)
 		return err
+	}
+
+	// Skip files without a Feature declaration (e.g., empty files or comment-only files)
+	if document.Feature == nil {
+		slog.Debug("skipping file without Feature declaration", "component", "index", "path", path)
+		return nil
 	}
 
 	index.mx.Lock()


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference when processing empty feature files or files with only comments
- Empty/comment-only feature files parse successfully but produce `document.Feature == nil`
- Now both `IndexWorkspaceFeatureFile` and `IndexDiskFeatureFile` skip files where `document.Feature` is nil

## Test plan
- [x] Added `workspace.feature` with 3 test scenarios for empty feature files
- [x] All existing tests pass (`CGO_ENABLED=0 go test ./testsuite/...`)
- [x] `godogen-language-server diagnose` no longer crashes on workspaces with empty feature files
- [x] `godogen-language-server find-references` no longer crashes