### PR TITLE
feat(lsp): skip hidden files and directories during discovery

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             version = builtins.readFile ./godogen-language-server/version.txt;
             src = godogenLanguageServerSrc;
             modRoot = "godogen-language-server";
-            vendorHash = "sha256-NnMPUpuSZ5J2kN2U0dmgt9ehO9eO4ZzKjNh50/9iBXQ=";
+            vendorHash = "sha256-VutZYd0NAlwTlSOzdV+x87riRg7j9ImvV0NGuDFFwgI=";
             ldflags = [
               "-s"
               "-w"

--- a/godogen-language-server/features/file-discovery.feature
+++ b/godogen-language-server/features/file-discovery.feature
@@ -101,6 +101,47 @@ Feature: File Discovery and Watching
       When file "test_steps.go" is deleted
       Then "test_steps.go" should be removed from index
 
+  Rule: Skip hidden files and directories
+
+    Scenario: Hidden directories are not watched
+      Given we watch pattern "**/*_steps.go"
+      And directory ".git" exists
+      And directory ".vscode" exists
+      And directory "src" exists
+      When discovery runs
+      Then directory ".git" should not be watched
+      And directory ".vscode" should not be watched
+      And directory "src" should be watched
+
+    Scenario: Files in hidden directories are not indexed
+      Given we watch pattern "**/*_steps.go"
+      And file ".git/hooks/pre-commit_steps.go" exists
+      And file "src/test_steps.go" exists
+      When discovery runs
+      Then ".git/hooks/pre-commit_steps.go" should not be indexed
+      And "src/test_steps.go" should be indexed
+
+    Scenario: Hidden files are not indexed
+      Given we watch pattern "**/*.go"
+      And file ".hidden.go" exists
+      And file "visible.go" exists
+      When discovery runs
+      Then ".hidden.go" should not be indexed
+      And "visible.go" should be indexed
+
+    Scenario: New hidden directory is not watched
+      Given we watch pattern "**/*_steps.go"
+      And discovery has run
+      When directory ".cache" is created
+      Then directory ".cache" should not be watched
+
+    Scenario: New file in hidden directory is not indexed
+      Given we watch pattern "**/*_steps.go"
+      And directory ".hidden" exists
+      And discovery has run
+      When file ".hidden/test_steps.go" is created
+      Then ".hidden/test_steps.go" should not be indexed
+
   Rule: Multiple patterns
 
     Scenario: Files matching any pattern are indexed

--- a/godogen-language-server/fsys/fs.go
+++ b/godogen-language-server/fsys/fs.go
@@ -137,6 +137,7 @@ func getWatchDir(pattern string) string {
 
 // discoverPattern discovers files matching a specific glob pattern.
 // Supports ** for recursive directory matching.
+// Hidden directories (starting with .) are skipped unless explicitly referenced in the pattern.
 func (w *Watcher) discoverPattern(pattern string) error {
 	// Get the base directory to search from (the part before any wildcards)
 	base := getWatchDir(pattern)
@@ -149,6 +150,12 @@ func (w *Watcher) discoverPattern(pattern string) error {
 		}
 
 		if d.IsDir() {
+			// Skip hidden directories
+			if strings.HasPrefix(d.Name(), ".") && d.Name() != "." && d.Name() != ".." {
+				slog.Debug("skipping hidden directory", "component", "fsys", "path", path)
+				return filepath.SkipDir
+			}
+
 			// Add directory to watcher if not already watching
 			if !w.watchedDirs[path] {
 				if err := w.watcher.Add(path); err != nil {
@@ -166,7 +173,7 @@ func (w *Watcher) discoverPattern(pattern string) error {
 		return fmt.Errorf("failed to walk directory tree: %w", err)
 	}
 
-	// Now discover files matching the pattern
+	// Now discover files matching the pattern using GlobWalk to skip hidden directories
 	fsys := os.DirFS(base)
 
 	// Make pattern relative to base for doublestar matching
@@ -175,42 +182,41 @@ func (w *Watcher) discoverPattern(pattern string) error {
 		relPattern = pattern
 	}
 
-	matches, err := doublestar.Glob(fsys, relPattern)
+	var matchCount int
+	err = doublestar.GlobWalk(fsys, relPattern, func(relMatch string, d fs.DirEntry) error {
+		if d.IsDir() {
+			return nil
+		}
+
+		match := filepath.Join(base, relMatch)
+
+		// Regular file - check if it's a .go or .feature file
+		ext := filepath.Ext(match)
+		if ext == ".go" || ext == ".feature" {
+			matchCount++
+			content, err := os.ReadFile(match)
+			if err != nil {
+				slog.Error("failed to read file", "component", "fsys", "path", match, "error", err)
+				return nil
+			}
+			if err := w.onFileChanged(match, content); err != nil {
+				slog.Error("failed to index file", "component", "fsys", "path", match, "error", err)
+			}
+		}
+
+		return nil
+	}, doublestar.WithNoHidden())
 	if err != nil {
 		return fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
 	}
 
-	slog.Debug("pattern matched", "component", "fsys", "pattern", pattern, "count", len(matches))
-
-	for _, relMatch := range matches {
-		match := filepath.Join(base, relMatch)
-
-		info, err := os.Stat(match)
-		if err != nil {
-			slog.Debug("failed to stat file", "component", "fsys", "path", match, "error", err)
-			continue
-		}
-
-		if !info.IsDir() {
-			// Regular file - check if it's a .go or .feature file
-			ext := filepath.Ext(match)
-			if ext == ".go" || ext == ".feature" {
-				content, err := os.ReadFile(match)
-				if err != nil {
-					slog.Error("failed to read file", "component", "fsys", "path", match, "error", err)
-					continue
-				}
-				if err := w.onFileChanged(match, content); err != nil {
-					slog.Error("failed to index file", "component", "fsys", "path", match, "error", err)
-				}
-			}
-		}
-	}
+	slog.Debug("pattern matched", "component", "fsys", "pattern", pattern, "count", matchCount)
 
 	return nil
 }
 
 // discover walks the directory and indexes all existing files.
+// Hidden directories (starting with .) are skipped.
 func (w *Watcher) discover(root string) error {
 	fsys, err := os.OpenRoot(root)
 	if err != nil {
@@ -222,7 +228,17 @@ func (w *Watcher) discover(root string) error {
 			return fmt.Errorf("failed to walk workspace root: %w", err)
 		}
 
+		// Skip hidden directories
+		if d.IsDir() && strings.HasPrefix(d.Name(), ".") && d.Name() != "." && d.Name() != ".." {
+			return filepath.SkipDir
+		}
+
 		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		// Skip hidden files
+		if strings.HasPrefix(d.Name(), ".") {
 			return nil
 		}
 
@@ -258,8 +274,12 @@ func (w *Watcher) watch(ctx context.Context) {
 
 			fileinfo, err := os.Stat(event.Name)
 
-			// Handle directory creation
+			// Handle directory creation (skip hidden directories)
 			if err == nil && fileinfo.IsDir() && event.Has(fsnotify.Create) {
+				if strings.HasPrefix(filepath.Base(event.Name), ".") {
+					slog.Debug("skipping hidden directory", "component", "fsys", "path", event.Name)
+					continue
+				}
 				slog.Debug("directory created", "component", "fsys", "path", event.Name)
 				w.handleNewDirectory(event.Name)
 				continue
@@ -272,6 +292,12 @@ func (w *Watcher) watch(ctx context.Context) {
 
 			deleted := os.IsNotExist(err) || event.Has(fsnotify.Remove) ||
 				event.Has(fsnotify.Rename)
+
+			// Skip hidden files
+			baseName := filepath.Base(event.Name)
+			if strings.HasPrefix(baseName, ".") {
+				continue
+			}
 
 			ext := filepath.Ext(event.Name)
 			if ext != ".go" && ext != ".feature" {
@@ -311,6 +337,7 @@ func (w *Watcher) watch(ctx context.Context) {
 
 // handleNewDirectory handles a newly created directory by adding it and its subdirectories
 // to the watcher, and discovering any files that match our patterns.
+// Hidden directories (starting with .) are skipped.
 func (w *Watcher) handleNewDirectory(dirPath string) {
 	// Walk the new directory tree and add all directories to the watcher
 	_ = filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
@@ -320,6 +347,12 @@ func (w *Watcher) handleNewDirectory(dirPath string) {
 		}
 
 		if d.IsDir() {
+			// Skip hidden directories
+			if strings.HasPrefix(d.Name(), ".") {
+				slog.Debug("skipping hidden directory", "component", "fsys", "path", path)
+				return filepath.SkipDir
+			}
+
 			// Add directory to watcher
 			if !w.watchedDirs[path] {
 				if err := w.watcher.Add(path); err != nil {
@@ -330,6 +363,11 @@ func (w *Watcher) handleNewDirectory(dirPath string) {
 				}
 			}
 		} else if d.Type().IsRegular() {
+			// Skip hidden files
+			if strings.HasPrefix(d.Name(), ".") {
+				return nil
+			}
+
 			// Check if file matches any of our patterns and has correct extension
 			ext := filepath.Ext(path)
 			if ext == ".go" || ext == ".feature" {

--- a/godogen-language-server/go.mod
+++ b/godogen-language-server/go.mod
@@ -4,6 +4,8 @@ go 1.25.1
 
 replace github.com/lukasngl/godogen => ../
 
+replace github.com/bmatcuk/doublestar/v4 => github.com/lukasngl/doublestar/v4 v4.9.2-nohidden
+
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/cucumber/gherkin/go/v36 v36.0.0

--- a/godogen-language-server/go.sum
+++ b/godogen-language-server/go.sum
@@ -1,7 +1,5 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
-github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cucumber/gherkin/go/v26 v26.2.0 h1:EgIjePLWiPeslwIWmNQ3XHcypPsWAHoMCz/YEBKP4GI=
@@ -49,6 +47,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/lukasngl/doublestar/v4 v4.9.2-nohidden h1:Y7HNRWz6tVvI1sTZ/FLI7rtxHrp6TeQxx44cJkLuWvQ=
+github.com/lukasngl/doublestar/v4 v4.9.2-nohidden/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=


### PR DESCRIPTION
## Summary
- Skip hidden directories (starting with `.`) during file discovery and watching
- Use `doublestar.WithNoHidden()` to follow traditional shell glob behavior
- Prevents indexing files in `.git`, `.vscode`, `.idea`, etc.

## Changes
Uses forked doublestar with `WithNoHidden()` support. Hidden directories/files are skipped in:
- `discoverPattern`: uses `WithNoHidden()` for glob matching + manual filtering for fsnotify setup
- `discover`: workspace discovery via filepath.WalkDir
- `watch`: new directory/file events
- `handleNewDirectory`: newly created directories

## Dependencies
Depends on doublestar fork: https://github.com/lukasngl/doublestar/tree/feat/no-hidden

Once the upstream PR is merged, the replace directive can be removed.

## Test plan
- Added BDD scenarios under "Rule: Skip hidden files and directories"