### PR TITLE
ci: add nix flake check to quality gate

### DIFF
--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -74,6 +74,18 @@ jobs:
       - name: Build all tools
         run: nix develop -c just build
 
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build all Nix packages
+        run: nix flake check
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -94,7 +106,7 @@ jobs:
 
   code-quality-check:
     runs-on: ubuntu-latest
-    needs: ["fmt", "gen", "tidy", "lint", "build", "test"]
+    needs: ["fmt", "gen", "tidy", "lint", "build", "nix-build", "test"]
     if: always()
     steps:
       - name: Check fmt
@@ -115,6 +127,10 @@ jobs:
         run: exit 1
       - name: Check build
         if: ${{ needs.build.result == 'failure' }}
+        shell: sh
+        run: exit 1
+      - name: Check nix-build
+        if: ${{ needs.nix-build.result == 'failure' }}
         shell: sh
         run: exit 1
       - name: Check test

--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,15 @@
           };
         };
 
+        # Re-export packages as checks so `nix flake check` builds them all
+        checks = {
+          inherit (self.packages.${system})
+            godogen
+            godogen-language-server
+            godogen-lint
+            ;
+        };
+
         devShells.tools = pkgs.mkShell {
           packages = [
             self.packages.${system}.godogen

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             version = builtins.readFile ./godogen-language-server/version.txt;
             src = godogenLanguageServerSrc;
             modRoot = "godogen-language-server";
-            vendorHash = "sha256-VutZYd0NAlwTlSOzdV+x87riRg7j9ImvV0NGuDFFwgI=";
+            vendorHash = "sha256-BwfqglO61HUY8WqaEJpnpKZ4kQ7dhIzC0I0OQRcYvsg=";
             ldflags = [
               "-s"
               "-w"
@@ -94,7 +94,7 @@
             version = builtins.readFile ./godogen-lint/version.txt;
             src = godogenLintSrc;
             modRoot = "godogen-lint";
-            vendorHash = "sha256-X0xUeCcvdGtfGb7W8VKDmF6oHZElerhPWOd13UkudOk=";
+            vendorHash = "sha256-XnSyGjfFSurCoYs8o1xCrSwEpEf9dAyl9Y8OKjL4ybM=";
             ldflags = [
               "-s"
               "-w"


### PR DESCRIPTION
## Summary

- Add `checks` output to `flake.nix` that re-exports all packages (godogen, godogen-lint, godogen-language-server)
- Add `nix-build` CI job that runs `nix flake check`, catching vendor hash mismatches before merging
- Include it in the `code-quality-check` gate