### PR TITLE
feat(lsp): suppress unused-step hints for external step definitions

### DIFF
--- a/godogen-language-server/cli/workspace.go
+++ b/godogen-language-server/cli/workspace.go
@@ -37,6 +37,7 @@ func LoadWorkspace(root, configPath string) (*Workspace, error) {
 
 	// Create index
 	idx := index.NewIndex()
+	idx.WorkspaceRoot = absRoot
 
 	// Discover and index files
 	if err := discoverFiles(absRoot, config.StepPatterns, idx); err != nil {

--- a/godogen-language-server/cmd/stdio.go
+++ b/godogen-language-server/cmd/stdio.go
@@ -210,6 +210,8 @@ func (srv *Server) initialize(
 		return nil, fmt.Errorf("root URI is not a file path: %s", *params.RootURI)
 	}
 
+	srv.index.WorkspaceRoot = path
+
 	// Load configuration with precedence: LSP options > config file > defaults
 	config := loadConfig(path, params.InitializationOptions)
 

--- a/godogen-language-server/features/unused_steps.feature
+++ b/godogen-language-server/features/unused_steps.feature
@@ -95,6 +95,51 @@ Feature: Unused Step Definitions
         func IHaveFruits(count int) {}
         """
 
+  Rule: External step definitions do not receive unused hints
+
+    Steps defined in files outside the workspace root are considered external
+    library code. Their usage cannot be fully determined, so unused hints
+    are suppressed for them.
+
+    Scenario: Step definition outside workspace root is not flagged as unused
+      Given the workspace root is /project
+      And /project/test.feature is added to the workspace:
+        """
+        Feature: Test
+          Scenario: Simple test
+            Given I have 5 cukes
+        """
+      Then /shared/lib/steps.go has the following diagnostics:
+        """go
+        package steps
+
+        //godogen:given ^I have (\d+) cukes$
+        func IHaveCukes(count int) {}
+
+        //godogen:given ^I have (\d+) melons$
+        func IHaveMelons(count int) {}
+        """
+
+    Scenario: Step definition inside workspace root is still flagged as unused
+      Given the workspace root is /project
+      And /project/test.feature is added to the workspace:
+        """
+        Feature: Test
+          Scenario: Simple test
+            Given I have 5 cukes
+        """
+      Then /project/steps.go has the following diagnostics:
+        """go
+        package steps
+
+        //godogen:given ^I have (\d+) cukes$
+        func IHaveCukes(count int) {}
+
+        //godogen:given ^I have (\d+) melons$
+        ^ HINT: Step definition is not used
+        func IHaveMelons(count int) {}
+        """
+
   Rule: Invalid patterns are not checked for usage
 
     Scenario: Invalid regex pattern is not checked

--- a/godogen-language-server/index/index.go
+++ b/godogen-language-server/index/index.go
@@ -31,6 +31,11 @@ import (
 type Index struct {
 	mx sync.RWMutex
 
+	// WorkspaceRoot is the root directory of the workspace. Files outside this
+	// directory are considered external (e.g. shared step libraries) and will
+	// not receive unused-step hints.
+	WorkspaceRoot string
+
 	Features map[string]*FeatureFileVersions
 	GoFiles  map[string]*GoFileVersions
 }
@@ -523,9 +528,12 @@ func (index *Index) GetDiagnostics(path string) []Diagnostic {
 	}
 
 	// Check for unused step definitions (only if there are feature files to use them)
-	// Skip this check if there are no feature files at all
+	// Skip this check if there are no feature files at all.
+	// Also skip for files outside the workspace root — these are external/library
+	// steps whose full usage across all consumers cannot be determined.
 	hasFeatureFiles := len(index.Features) > 0
-	if hasFeatureFiles {
+	isExternal := index.WorkspaceRoot != "" && !strings.HasPrefix(path, index.WorkspaceRoot+string(filepath.Separator)) && path != index.WorkspaceRoot
+	if hasFeatureFiles && !isExternal {
 		for _, stepFunc := range goFile.StepFuncs {
 			for _, stepDef := range stepFunc.Steps {
 				// Skip invalid patterns - they already have validation errors

--- a/godogen-language-server/index/indextest/steps.go
+++ b/godogen-language-server/index/indextest/steps.go
@@ -13,6 +13,12 @@ import (
 	"github.com/lukasngl/godogen/godogen-language-server/index"
 )
 
+//godogen:given ^the workspace root is (.+)$
+func (tc *TestContext) SetWorkspaceRoot(root string) error {
+	tc.index.WorkspaceRoot = root
+	return nil
+}
+
 //godogen:given ^(.+) is added to the workspace:$
 func (tc *TestContext) AddFileToWorkspace(path string, content *godog.DocString) error {
 	return tc.addFileToWorkspace(path, content.Content)

--- a/godogen-language-server/index/indextest/steps_initialize.go
+++ b/godogen-language-server/index/indextest/steps_initialize.go
@@ -11,6 +11,7 @@ func InitializeSteps(sc *godog.ScenarioContext, r1 *TestContext) {
 	//
 	// Note: there must be no space between the "//" and the "godogen:step",
 	// see "directive comment" in https://tip.golang.org/doc/comment#syntax
+	sc.Given(`^the workspace root is (.+)$`, r1.SetWorkspaceRoot)
 	sc.Given(`^(.+) is added to the workspace:$`, r1.AddFileToWorkspace)
 	sc.Given(`^(.+) is added to the filesystem:$`, r1.AddFileToFilesystem)
 	sc.When(`^I request step definitions for (.+) line (\d+)$`, r1.RequestStepDefinitions)


### PR DESCRIPTION
## Summary

- Add `WorkspaceRoot` field to `Index` to track the workspace boundary
- Skip unused-step hint diagnostics for Go files outside the workspace root
- These are external/library steps (e.g. shared step libraries in a monorepo) whose full usage across all consumers cannot be determined

Fixes #35

## Test plan

- [x] Added BDD scenario: external file outside workspace root gets no unused hints
- [x] Added BDD scenario: file inside workspace root still gets unused hints
- [x] All existing tests pass