### PR TITLE
feat(lsp): improve diagnostic output formatting

### DIFF
--- a/godogen-language-server/cmd/diagnose.go
+++ b/godogen-language-server/cmd/diagnose.go
@@ -55,10 +55,12 @@ type diagnoseResult struct {
 }
 
 type diagnoseSummary struct {
-	Errors   int `json:"errors"`
-	Warnings int `json:"warnings"`
-	Hints    int `json:"hints"`
-	Total    int `json:"total"`
+	Errors               int `json:"errors"`
+	Warnings             int `json:"warnings"`
+	Hints                int `json:"hints"`
+	Total                int `json:"total"`
+	AffectedFeatureFiles int `json:"affectedFeatureFiles"`
+	TotalFeatureFiles    int `json:"totalFeatureFiles"`
 }
 
 func runDiagnose(_ *cobra.Command, _ []string) error {
@@ -114,7 +116,10 @@ func runDiagnose(_ *cobra.Command, _ []string) error {
 	})
 
 	// Calculate summary
-	summary := diagnoseSummary{}
+	summary := diagnoseSummary{
+		TotalFeatureFiles: len(ws.AllFeatureFiles()),
+	}
+	affectedFiles := make(map[string]struct{})
 	for _, d := range diagnostics {
 		switch d.Severity {
 		case "error":
@@ -125,7 +130,12 @@ func runDiagnose(_ *cobra.Command, _ []string) error {
 			summary.Hints++
 		}
 		summary.Total++
+
+		if strings.HasSuffix(d.File, ".feature") {
+			affectedFiles[d.File] = struct{}{}
+		}
 	}
+	summary.AffectedFeatureFiles = len(affectedFiles)
 
 	result := diagnoseResult{
 		Diagnostics: diagnostics,
@@ -185,13 +195,14 @@ func outputDiagnoseText(result diagnoseResult) error {
 	for _, d := range result.Diagnostics {
 		fmt.Printf("%s:%d:%d: %s: %s\n", d.File, d.Line, d.Column, d.Severity, d.Message)
 		for _, rel := range d.RelatedInfo {
-			fmt.Printf("  -> %s:%d:%d: %s\n", rel.File, rel.Line, rel.Column, rel.Message)
+			fmt.Printf("  %s:%d:%d: note: %s\n", rel.File, rel.Line, rel.Column, rel.Message)
 		}
 	}
 
 	if result.Summary.Total > 0 {
-		fmt.Printf("\nSummary: %d errors, %d warnings, %d hints\n",
-			result.Summary.Errors, result.Summary.Warnings, result.Summary.Hints)
+		fmt.Printf("\nSummary: %d errors, %d warnings, %d hints in %d/%d feature files\n",
+			result.Summary.Errors, result.Summary.Warnings, result.Summary.Hints,
+			result.Summary.AffectedFeatureFiles, result.Summary.TotalFeatureFiles)
 	} else {
 		fmt.Println("No diagnostics found.")
 	}

--- a/godogen-language-server/features/unused_steps.feature
+++ b/godogen-language-server/features/unused_steps.feature
@@ -20,7 +20,7 @@ Feature: Unused Step Definitions
         func IHaveCukes(count int) {}
 
         //godogen:given ^I have (\d+) melons$
-        ^ HINT: Step definition is not used
+        ^ HINT: Step definition is not used in any feature file: Given ^I have (\d+) melons$
         func IHaveMelons(count int) {}
         """
 
@@ -55,7 +55,7 @@ Feature: Unused Step Definitions
         package steps
 
         //godogen:given ^I have (\d+) cukes$
-        ^ HINT: Step definition is not used
+        ^ HINT: Step definition is not used in any feature file: Given ^I have (\d+) cukes$
         func IHaveCukes(count int) {}
         """
 
@@ -91,7 +91,7 @@ Feature: Unused Step Definitions
 
         //godogen:given ^I have (\d+) cukes$
         //godogen:given ^I have (\d+) melons$
-        ^ HINT: Step definition is not used
+        ^ HINT: Step definition is not used in any feature file: Given ^I have (\d+) melons$
         func IHaveFruits(count int) {}
         """
 
@@ -136,7 +136,7 @@ Feature: Unused Step Definitions
         func IHaveCukes(count int) {}
 
         //godogen:given ^I have (\d+) melons$
-        ^ HINT: Step definition is not used
+        ^ HINT: Step definition is not used in any feature file: Given ^I have (\d+) melons$
         func IHaveMelons(count int) {}
         """
 

--- a/godogen-language-server/index/index.go
+++ b/godogen-language-server/index/index.go
@@ -560,7 +560,7 @@ func (index *Index) GetDiagnostics(path string) []Diagnostic {
 					StartColumn: start.Column,
 					EndLine:     end.Line,
 					EndColumn:   end.Column,
-					Message:     "Step definition is not used in any feature file",
+					Message:     fmt.Sprintf("Step definition is not used in any feature file: %s %s", stepDef.Kind, stepDef.Pattern),
 					Severity:    DiagnosticSeverityHint,
 				})
 			}


### PR DESCRIPTION
## Summary

- Include step kind and pattern in unused-step hint messages (e.g. `Given ^pattern$`)
- Use standard related-info format with `note:` prefix instead of `->` arrow
- Add per-file feature summary to diagnose output (`N/M feature files`)

Closes #36

## Test plan

- [x] `go build ./...`
- [x] `cd godogen-language-server && go test ./testsuite/`
- [x] `cd test && go test ./...`